### PR TITLE
Cosmetics: acknowledging Heidelberg in the PN Footer

### DIFF
--- a/pn-site/about.html
+++ b/pn-site/about.html
@@ -102,7 +102,8 @@
         <p>Produced by</p>
         <p><a href="http://blogs.library.duke.edu/dcthree/">The Duke Collaboratory for Classics Computing</a>
           <br/>&amp; the <a href="http://www.nyu.edu/isaw/">Institute for the Study of the
-          Ancient World</a></p>
+          Ancient World</a>
+          <br/>&amp; the <a href="http://www.uni-heidelberg.de/fakultaeten/philosophie/zaw/papy/">Institute of Papyrology Heidelberg</a></p>
         <div id="about-nav">
           <ul class="nav">
             <li><a href="http://www.ulb.ac.be/philo/cpeg/bp.htm" title="Bibliographie Papyrologique Home">BP</a></li>

--- a/pn-site/authorbrowse.html
+++ b/pn-site/authorbrowse.html
@@ -95,7 +95,8 @@
         <p>Produced by</p>
         <p><a href="http://blogs.library.duke.edu/dcthree/">The Duke Collaboratory for Classics Computing</a>
           <br/>&amp; the <a href="http://www.nyu.edu/isaw/">Institute for the Study of the
-          Ancient World</a></p>
+          Ancient World</a>
+          <br/>&amp; the <a href="http://www.uni-heidelberg.de/fakultaeten/philosophie/zaw/papy/">Institute of Papyrology Heidelberg</a></p>
         <div id="about-nav">
           <ul class="nav">
             <li><a href="http://www.ulb.ac.be/philo/cpeg/bp.htm" title="Bibliographie Papyrologique Home">BP</a></li>

--- a/pn-site/feedback.html
+++ b/pn-site/feedback.html
@@ -92,7 +92,8 @@
         <p>Produced by</p>
         <p><a href="http://blogs.library.duke.edu/dcthree/">The Duke Collaboratory for Classics Computing</a>
           <br/>&amp; the <a href="http://www.nyu.edu/isaw/">Institute for the Study of the
-          Ancient World</a></p>
+          Ancient World</a>
+          <br/>&amp; the <a href="http://www.uni-heidelberg.de/fakultaeten/philosophie/zaw/papy/">Institute of Papyrology Heidelberg</a></p>
         <div id="about-nav">
           <ul class="nav">
             <li><a href="http://www.ulb.ac.be/philo/cpeg/bp.htm" title="Bibliographie Papyrologique Home">BP</a></li>

--- a/pn-site/force-graph.html
+++ b/pn-site/force-graph.html
@@ -155,7 +155,8 @@
         <p>Produced by</p>
         <p><a href="http://blogs.library.duke.edu/dcthree/">The Duke Collaboratory for Classics Computing</a>
           <br/>&amp; the <a href="http://www.nyu.edu/isaw/">Institute for the Study of the
-          Ancient World</a></p>
+          Ancient World</a>
+          <br/>&amp; the <a href="http://www.uni-heidelberg.de/fakultaeten/philosophie/zaw/papy/">Institute of Papyrology Heidelberg</a></p>
         <div id="about-nav">
           <ul class="nav">
             <li><a href="http://www.ulb.ac.be/philo/cpeg/bp.htm" title="Bibliographie Papyrologique Home">BP</a></li>

--- a/pn-site/index.html
+++ b/pn-site/index.html
@@ -131,7 +131,8 @@
         <p>Produced by</p>
         <p><a href="http://blogs.library.duke.edu/dcthree/">The Duke Collaboratory for Classics Computing</a>
           <br/>&amp; the <a href="http://www.nyu.edu/isaw/">Institute for the Study of the
-          Ancient World</a></p>
+          Ancient World</a>
+          <br/>&amp; the <a href="http://www.uni-heidelberg.de/fakultaeten/philosophie/zaw/papy/">Institute of Papyrology Heidelberg</a></p>
         <div id="about-nav">
           <ul class="nav">
             <li><a href="http://www.ulb.ac.be/philo/cpeg/bp.htm" title="Bibliographie Papyrologique Home">BP</a></li>

--- a/pn-site/resources.html
+++ b/pn-site/resources.html
@@ -192,7 +192,8 @@
         <p>Produced by</p>
         <p><a href="http://blogs.library.duke.edu/dcthree/">The Duke Collaboratory for Classics Computing</a>
           <br/>&amp; the <a href="http://www.nyu.edu/isaw/">Institute for the Study of the
-          Ancient World</a></p>
+          Ancient World</a>
+          <br/>&amp; the <a href="http://www.uni-heidelberg.de/fakultaeten/philosophie/zaw/papy/">Institute of Papyrology Heidelberg</a></p>
         <div id="about-nav">
           <ul class="nav">
             <li><a href="http://www.ulb.ac.be/philo/cpeg/bp.htm" title="Bibliographie Papyrologique Home">BP</a></li>

--- a/pn-site/search.html
+++ b/pn-site/search.html
@@ -207,7 +207,8 @@
         <p>Produced by</p>
         <p><a href="http://blogs.library.duke.edu/dcthree/">The Duke Collaboratory for Classics Computing</a>
           <br/>&amp; the <a href="http://www.nyu.edu/isaw/">Institute for the Study of the
-          Ancient World</a></p>
+          Ancient World</a>
+          <br/>&amp; the <a href="http://www.uni-heidelberg.de/fakultaeten/philosophie/zaw/papy/">Institute of Papyrology Heidelberg</a></p>
         <div id="about-nav">
           <ul class="nav">
             <li><a href="http://www.trismegistos.org/" title="Trismegistos Home">Trismegistos</a></li>

--- a/pn-site/template.html
+++ b/pn-site/template.html
@@ -94,7 +94,8 @@
         <p>Produced by</p>
         <p><a href="http://blogs.library.duke.edu/dcthree/">The Duke Collaboratory for Classics Computing</a>
           <br/>&amp; the <a href="http://www.nyu.edu/isaw/">Institute for the Study of the
-          Ancient World</a></p>
+          Ancient World</a>
+          <br/>&amp; the <a href="http://www.uni-heidelberg.de/fakultaeten/philosophie/zaw/papy/">Institute of Papyrology Heidelberg</a></p>
         <div id="about-nav">
           <ul class="nav">
             <li><a href="http://www.ulb.ac.be/philo/cpeg/bp.htm" title="Bibliographie Papyrologique Home">BP</a></li>


### PR DESCRIPTION
I noticed that the PE footer includes Heidelberg in its list of `Produced by`: 
<img width="352" alt="Screenshot 2023-09-22 at 2 39 04 PM" src="https://github.com/papyri/navigator/assets/61889129/f13c37dc-5d50-46f9-9f48-821afde2ac9c">
(this is controlled by [sosol/app/views/cross_site/_footer.html.erb](https://github.com/papyri/sosol/blob/ae0e0b8947146e793dfa7fe949052eaff49517b7/app/views/cross_site/_footer.html.erb#L19-L23))

```
        <p>Produced by</p>
        <p><a href="http://blogs.library.duke.edu/dcthree/">The Duke Collaboratory for Classics Computing</a> 
          <br/>&amp; the <a href="http://www.nyu.edu/isaw/">Institute for the Study of the Ancient World</a> 
          <br/>&amp; the <a href="http://www.uni-heidelberg.de/fakultaeten/philosophie/zaw/papy/">Institute of Papyrology Heidelberg</a>
        </p>
```

But the same is not true across PN. I've therefore added the relevant line of html to the various files in `papyri/navigator/pn-site` where it is missing, on the assumption that its omission is simply an oversight.  

<img width="371" alt="Screenshot 2023-09-22 at 2 40 20 PM" src="https://github.com/papyri/navigator/assets/61889129/83caf491-f31d-44d3-85b9-b105fe118981">
