### PR TITLE
Dynamic links to MP3 catalog

### DIFF
--- a/pn-site/about.html
+++ b/pn-site/about.html
@@ -102,7 +102,8 @@
         <p>Produced by</p>
         <p><a href="http://blogs.library.duke.edu/dcthree/">The Duke Collaboratory for Classics Computing</a>
           <br/>&amp; the <a href="http://www.nyu.edu/isaw/">Institute for the Study of the
-          Ancient World</a></p>
+          Ancient World</a>
+          <br/>&amp; the <a href="http://www.uni-heidelberg.de/fakultaeten/philosophie/zaw/papy/">Institute of Papyrology Heidelberg</a></p>
         <div id="about-nav">
           <ul class="nav">
             <li><a href="http://www.ulb.ac.be/philo/cpeg/bp.htm" title="Bibliographie Papyrologique Home">BP</a></li>

--- a/pn-site/authorbrowse.html
+++ b/pn-site/authorbrowse.html
@@ -95,7 +95,8 @@
         <p>Produced by</p>
         <p><a href="http://blogs.library.duke.edu/dcthree/">The Duke Collaboratory for Classics Computing</a>
           <br/>&amp; the <a href="http://www.nyu.edu/isaw/">Institute for the Study of the
-          Ancient World</a></p>
+          Ancient World</a>
+          <br/>&amp; the <a href="http://www.uni-heidelberg.de/fakultaeten/philosophie/zaw/papy/">Institute of Papyrology Heidelberg</a></p>
         <div id="about-nav">
           <ul class="nav">
             <li><a href="http://www.ulb.ac.be/philo/cpeg/bp.htm" title="Bibliographie Papyrologique Home">BP</a></li>

--- a/pn-site/feedback.html
+++ b/pn-site/feedback.html
@@ -92,7 +92,8 @@
         <p>Produced by</p>
         <p><a href="http://blogs.library.duke.edu/dcthree/">The Duke Collaboratory for Classics Computing</a>
           <br/>&amp; the <a href="http://www.nyu.edu/isaw/">Institute for the Study of the
-          Ancient World</a></p>
+          Ancient World</a>
+          <br/>&amp; the <a href="http://www.uni-heidelberg.de/fakultaeten/philosophie/zaw/papy/">Institute of Papyrology Heidelberg</a></p>
         <div id="about-nav">
           <ul class="nav">
             <li><a href="http://www.ulb.ac.be/philo/cpeg/bp.htm" title="Bibliographie Papyrologique Home">BP</a></li>

--- a/pn-site/force-graph.html
+++ b/pn-site/force-graph.html
@@ -155,7 +155,8 @@
         <p>Produced by</p>
         <p><a href="http://blogs.library.duke.edu/dcthree/">The Duke Collaboratory for Classics Computing</a>
           <br/>&amp; the <a href="http://www.nyu.edu/isaw/">Institute for the Study of the
-          Ancient World</a></p>
+          Ancient World</a>
+          <br/>&amp; the <a href="http://www.uni-heidelberg.de/fakultaeten/philosophie/zaw/papy/">Institute of Papyrology Heidelberg</a></p>
         <div id="about-nav">
           <ul class="nav">
             <li><a href="http://www.ulb.ac.be/philo/cpeg/bp.htm" title="Bibliographie Papyrologique Home">BP</a></li>

--- a/pn-site/index.html
+++ b/pn-site/index.html
@@ -131,7 +131,8 @@
         <p>Produced by</p>
         <p><a href="http://blogs.library.duke.edu/dcthree/">The Duke Collaboratory for Classics Computing</a>
           <br/>&amp; the <a href="http://www.nyu.edu/isaw/">Institute for the Study of the
-          Ancient World</a></p>
+          Ancient World</a>
+          <br/>&amp; the <a href="http://www.uni-heidelberg.de/fakultaeten/philosophie/zaw/papy/">Institute of Papyrology Heidelberg</a></p>
         <div id="about-nav">
           <ul class="nav">
             <li><a href="http://www.ulb.ac.be/philo/cpeg/bp.htm" title="Bibliographie Papyrologique Home">BP</a></li>

--- a/pn-site/resources.html
+++ b/pn-site/resources.html
@@ -192,7 +192,8 @@
         <p>Produced by</p>
         <p><a href="http://blogs.library.duke.edu/dcthree/">The Duke Collaboratory for Classics Computing</a>
           <br/>&amp; the <a href="http://www.nyu.edu/isaw/">Institute for the Study of the
-          Ancient World</a></p>
+          Ancient World</a>
+          <br/>&amp; the <a href="http://www.uni-heidelberg.de/fakultaeten/philosophie/zaw/papy/">Institute of Papyrology Heidelberg</a></p>
         <div id="about-nav">
           <ul class="nav">
             <li><a href="http://www.ulb.ac.be/philo/cpeg/bp.htm" title="Bibliographie Papyrologique Home">BP</a></li>

--- a/pn-site/search.html
+++ b/pn-site/search.html
@@ -207,7 +207,8 @@
         <p>Produced by</p>
         <p><a href="http://blogs.library.duke.edu/dcthree/">The Duke Collaboratory for Classics Computing</a>
           <br/>&amp; the <a href="http://www.nyu.edu/isaw/">Institute for the Study of the
-          Ancient World</a></p>
+          Ancient World</a>
+          <br/>&amp; the <a href="http://www.uni-heidelberg.de/fakultaeten/philosophie/zaw/papy/">Institute of Papyrology Heidelberg</a></p>
         <div id="about-nav">
           <ul class="nav">
             <li><a href="http://www.trismegistos.org/" title="Trismegistos Home">Trismegistos</a></li>

--- a/pn-site/template.html
+++ b/pn-site/template.html
@@ -94,7 +94,8 @@
         <p>Produced by</p>
         <p><a href="http://blogs.library.duke.edu/dcthree/">The Duke Collaboratory for Classics Computing</a>
           <br/>&amp; the <a href="http://www.nyu.edu/isaw/">Institute for the Study of the
-          Ancient World</a></p>
+          Ancient World</a>
+          <br/>&amp; the <a href="http://www.uni-heidelberg.de/fakultaeten/philosophie/zaw/papy/">Institute of Papyrology Heidelberg</a></p>
         <div id="about-nav">
           <ul class="nav">
             <li><a href="http://www.ulb.ac.be/philo/cpeg/bp.htm" title="Bibliographie Papyrologique Home">BP</a></li>


### PR DESCRIPTION
CEDOPAL's online Mertens-Pack catalog has a new system of hyperlinks, which take the form `http://www.cedopalmp3.uliege.be/cdp_MP3_display.aspx?numNot=01411.000`. The numeral at the end of the link is the MP3 number (i.e., `01411.000`), which will always have the form `\d{5}\.\d{3}`. 

This commit adds to the XSL for dclp-metadata, enabling the dynamic construction of hyperlinks to the MP3 catalogue by appending the value of `idno[@type='MP3']` to the base URL, concatenating with `; ` as a separator where multiple values appear.