### PR TITLE
Dynamic links to MP3

### DIFF
--- a/pn-xslt/metadata-dclp.xsl
+++ b/pn-xslt/metadata-dclp.xsl
@@ -33,7 +33,10 @@
                 <th class="rowheader">Catalog(s)</th>
                 <td>
                     <xsl:for-each select="t:teiHeader/t:fileDesc/t:publicationStmt/t:idno[@type='MP3']">
-                        <xsl:value-of select="concat('MP3 ',.)"/>
+                        <xsl:text>MP3 </xsl:text>
+                    <a href="{concat('http://www.cedopalmp3.uliege.be/cdp_MP3_display.aspx?numNot=', .)}">
+                        <xsl:value-of select="."/>
+                    </a>
                         <xsl:if test="position() != last()"><xsl:text>; </xsl:text></xsl:if>
                     </xsl:for-each>
                 </td>


### PR DESCRIPTION
Modified XSLT to generate dynamic links to the MP3 catalog, using MP3 numbers in the proprietary `\d{5}\.\d{3}` format. Tested via [`63194.xml`](https://papyri.info/dclp/63194), where `count(//idno[@type='MP3']) > 1`.

Apologies for the second pull request on this issue; an attempt to keep the commits of discrete pull requests using branches failed, and so I closed those to begin anew.