### PR TITLE
Add link to BL-online

### DIFF
--- a/pn-xslt/metadata.xsl
+++ b/pn-xslt/metadata.xsl
@@ -510,7 +510,8 @@
     <tr>
       <th class="rowheader" rowspan="1">Post-Concordance BL Entries</th>
       <td>
-        <xsl:for-each select=".//t:bibl"><xsl:value-of select="normalize-space(.)"/><xsl:if test="position() != last()">; </xsl:if></xsl:for-each>
+        <xsl:if test=".//t:bibl[@type='BL-online']"><a href="{../t:bibl[@type='BL-online']/t:ptr/@target}">BL-online</a><xsl:text>; </xsl:text></xsl:if>
+        <xsl:for-each select=".//t:bibl[@type='BL']"><xsl:value-of select="normalize-space(.)"/><xsl:if test="position() != last()">; </xsl:if></xsl:for-each>
       </td>
     </tr>
   </xsl:template>

--- a/pn-xslt/metadata.xsl
+++ b/pn-xslt/metadata.xsl
@@ -510,7 +510,7 @@
     <tr>
       <th class="rowheader" rowspan="1">Post-Concordance BL Entries</th>
       <td>
-        <xsl:if test=".//t:bibl[@type='BL-online']"><a href="{../t:bibl[@type='BL-online']/t:ptr/@target}">BL-online</a><xsl:text>; </xsl:text></xsl:if>
+        <xsl:if test=".//t:bibl[@type='BL-online']"><a href="{.//t:bibl[@type='BL-online']/t:ptr/@target}">BL-online</a><xsl:text>; </xsl:text></xsl:if>
         <xsl:for-each select=".//t:bibl[@type='BL']"><xsl:value-of select="normalize-space(.)"/><xsl:if test="position() != last()">; </xsl:if></xsl:for-each>
       </td>
     </tr>


### PR DESCRIPTION
This commit surfaces links to BL-online. 

In the first line, where there exists a link in `HGV` under `//div[@type='bibliography' and @subtype='corrections']/listBibl/bibl[@type='BL-online']`, the text `BL-online` is created with a link whose value derives from `./ptr/@target`. A semi-colon with trailing whitespace are also added.

In the second line, the existing XSLT is modified slightly, to fire only on `bibl[@type='BL']` (where previously it fired on `bibl` universally). 