### PR TITLE
Uses commons-text to escape html for safer output

### DIFF
--- a/pn-dispatcher/pom.xml
+++ b/pn-dispatcher/pom.xml
@@ -55,6 +55,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+      <version>1.13.0</version>
+    </dependency>
+    <dependency>
       <groupId>com.vladsch.flexmark</groupId>
       <artifactId>flexmark-all</artifactId>
       <version>0.62.2</version>

--- a/pn-dispatcher/src/main/java/info/papyri/dispatch/browse/facet/FacetBrowser.java
+++ b/pn-dispatcher/src/main/java/info/papyri/dispatch/browse/facet/FacetBrowser.java
@@ -727,7 +727,7 @@ public class FacetBrowser extends HttpServlet {
             if (!"".equals(displayName)) {
               values.append("<span class='semicolon'>:</span> ");
             }
-            values.append(StringEscapeUtils.escapeHtml4(displayFacetValue));
+            values.append(displayFacetValue);
             values.append("</div><!-- closing .constraint-label -->");
             values.append("<div class='constraint-closer'>");
             values.append("<a href='");

--- a/pn-dispatcher/src/main/java/info/papyri/dispatch/browse/facet/FacetBrowser.java
+++ b/pn-dispatcher/src/main/java/info/papyri/dispatch/browse/facet/FacetBrowser.java
@@ -31,6 +31,7 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrServerException;
@@ -726,13 +727,13 @@ public class FacetBrowser extends HttpServlet {
             if (!"".equals(displayName)) {
               values.append("<span class='semicolon'>:</span> ");
             }
-            values.append(displayFacetValue);
+            values.append(StringEscapeUtils.escapeHtml4(displayFacetValue));
             values.append("</div><!-- closing .constraint-label -->");
             values.append("<div class='constraint-closer'>");
             values.append("<a href='");
             values.append(FACET_PATH);
             values.append("".equals(queryString) ? "" : "?");
-            values.append(queryString);
+            values.append(StringEscapeUtils.escapeHtml4(queryString));
             values.append("' title ='Remove facet value'>X</a>");
             values.append("</div><!-- closing .constraint-closer -->");
             values.append("<div class='spacer'></div>");


### PR DESCRIPTION
This is what I had tested. I may have missed elsewhere in the request processing where other filter behavior occurs @hcayless 