### PR TITLE
Add link to new BP en ligne

### DIFF
--- a/pn-xslt/htm-teibibl.xsl
+++ b/pn-xslt/htm-teibibl.xsl
@@ -200,7 +200,8 @@
   <xsl:template name="bpId">
     <xsl:choose>
       <xsl:when test="string(//t:idno[@type='bp'])">
-        No: <xsl:value-of select="//t:idno[@type='bp']"/><br/>
+        <xsl:variable name="bpIdno" select="//t:idno[@type='bp']"/>
+        No: <a href="{concat('https://bibpap.be/BP_enl/?n=',$bpIdno)}"><xsl:value-of select="$bpIdno"/></a><br/>
       </xsl:when>
       <xsl:when test="string(//t:idno[@type='bp_old'])">
         Ancien No: <xsl:value-of select="//t:idno[@type='bp_old']"/><br/>


### PR DESCRIPTION
BP en ligne has a new web address, and has at my request implemented URIs that lack ampersands, to permit the modification of PN XSLT, to generate hyperlinks to BP from our biblio records. 

This commit defines a variable `$bpIdno` as the value of `//t:idno[@type='bp']` and then calls that variable twice: once in html's `a/@href` (where it is concatenated with the new web address endpoint, as its parameter), and once as the value of that `a/@href` element.